### PR TITLE
Soure RPMs and CI/CD

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -7,8 +7,11 @@ on: [push]
 jobs:
   rpm:
     runs-on: ubuntu-20.04
-    container: bcumming/bci-base-rpmbuilder:testing
+    container: registry.suse.com/bci/bci-base:15.4.27.8.3
     steps:
+      - name: setup dependencies
+        run: |
+          zypper install -y libmount-devel gcc make rpm-build git sudo
       - name: clone
         uses: actions/checkout@v2
       - name: build-srpm
@@ -37,4 +40,3 @@ jobs:
         with:
           files:
             squashfs-mount*.src.rpm
-

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -9,11 +9,13 @@ jobs:
     runs-on: ubuntu-20.04
     container: registry.suse.com/bci/bci-base:15.4.27.8.3
     steps:
+      - name: setup-environment
+        run: |
+          zypper install -y libmount-devel gcc make rpm-build git sudo
       - name: clone
         uses: actions/checkout@v2
       - name: build-srpm
         run: |
-          zypper install -y libmount-devel gcc make rpm-build sudo
           make rpm
           sudo rpmbuild --rebuild ./rpmbuild/SRPMS/squashfs-mount*.src.rpm --define "_topdir $(pwd)/rpmbuild"
           sudo rpm --install rpmbuild/RPMS/x86_64/squashfs-mount*.rpm

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,40 @@
+name: artifacts
+on: [push]
+
+## Tests that all artifacts can be built on every push.
+## Uploads the artifacts to the GitHub release page for tags.
+
+jobs:
+  rpm:
+    runs-on: ubuntu-20.04
+    container: bcumming/bci-base-rpmbuilder:testing
+    steps:
+      - name: clone
+        uses: actions/checkout@v2
+      - name: build-srpm
+        run: |
+          make rpm
+          sudo rpmbuild --rebuild ./rpmbuild/SRPMS/squashfs-mount*.src.rpm --define "_topdir $(pwd)/rpmbuild"
+          sudo rpm --install rpmbuild/RPMS/x86_64/squashfs-mount*.rpm
+          cp rpmbuild/SRPMS/* .
+      - name: upload-rpm
+        uses: actions/upload-artifact@v3
+        with:
+          name: rpm
+          path: squashfs-mount*.src.rpm
+
+  tag-release:
+    runs-on: ubuntu-20.04
+    needs: rpm
+    steps:
+      - name: download-artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: rpm
+      - name: release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files:
+            squashfs-mount*.src.rpm
+

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -9,13 +9,11 @@ jobs:
     runs-on: ubuntu-20.04
     container: registry.suse.com/bci/bci-base:15.4.27.8.3
     steps:
-      - name: setup dependencies
-        run: |
-          zypper install -y libmount-devel gcc make rpm-build git sudo
       - name: clone
         uses: actions/checkout@v2
       - name: build-srpm
         run: |
+          zypper install -y libmount-devel gcc make rpm-build sudo
           make rpm
           sudo rpmbuild --rebuild ./rpmbuild/SRPMS/squashfs-mount*.src.rpm --define "_topdir $(pwd)/rpmbuild"
           sudo rpm --install rpmbuild/RPMS/x86_64/squashfs-mount*.rpm

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,36 @@
+name: builds
+on: [push]
+
+jobs:
+  makefile:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y util-linux libmount-dev
+      - name: build
+        run: |
+          sudo make install-suid
+      - name: test
+        run: . ci/test-mount.sh
+
+  meson:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build util-linux libmount-dev
+          # can't install as user because we need `sudo meson install` later
+          sudo pip3 install meson
+      - name: build
+        run: |
+          meson setup build
+          meson compile -C build
+          sudo meson install -C build
+      - name: test
+        run: . ci/test-mount.sh
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.o
 *.squashfs
 squashfs-mount
+rpmbuild
+*.sqsh
+test-dir

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,5 @@
+On master, to create a tag:
+```bash
+git tag -a v0.3.0 -m 'version 0.3.0'
+git push origin v0.3.0
+```

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,5 +1,35 @@
-On master, to create a tag:
+## Workflow
+
+The development workflow is simple: develop feature, enhancement and fix its own separate branch, then make a pull request.
+* don't merge PRs without one aproving review
+* don't merge PRs if all tests don't pass
+* use squash merges so that there is a single commit to the `master` for each PR that represents a tested and working version of the software.
+
+### Releases
+
+Release frequently, following semantic versioning.
+
+To release, update the `VERSION` file to create and create a tag.
 ```bash
-git tag -a v0.3.0 -m 'version 0.3.0'
-git push origin v0.3.0
+# edit the VERSION file, e.g. from '0.4.0-dev' to '0.4.0'
+vim VERSION
+# make a PR that bumps the version
+git ...
+
+# then create a tag and push.
+git tag -a "v$(echo VERSION)" -m "tag and release version $(echo version)"
+git push origin "v$(echo VERSION)"
+
+# Then update the VERSION file to dev status again e.g. to '0.5.0-dev'
+# And make a PR
+git ...
 ```
+
+## CI/CD
+
+There are two GitHub Actions workflows for testing that:
+1. the makefile and meson build systems can build, install working versions of squashfs-mount.
+2. the workflow for creating artifacts (currently a source RPM).
+
+All workflows run on each push and PR. Furthermore, the artifacts workflow, [`.github/workflows/artifacts.yml`](https://github.com/eth-cscs/squashfs-mount/blob/master/.github/workflows/artifacts.yml), runs a `tag-release` job when a tag is created, that automatically generates a GitHub release and uploads the artifacts to the release.
+

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,15 +1,15 @@
 ## Workflow
 
-The development workflow is simple: develop feature, enhancement and fix its own separate branch, then make a pull request.
-* don't merge PRs without one aproving review
-* don't merge PRs if all tests don't pass
-* use squash merges so that there is a single commit to the `master` for each PR that represents a tested and working version of the software.
+The development workflow is simple: develop feature, enhancement and fix its own separate branch, then make a pull request:
+* Don't merge PRs without one approving review.
+* Don't merge PRs if all tests don't pass.
+* Squash merge so that there is a single commit to the `master` for each PR that is a tested and working version of the software.
 
 ### Releases
 
 Release frequently, following semantic versioning.
 
-To release, update the `VERSION` file to create and create a tag.
+To release, update the `VERSION` file to create and create a tag. An example workflow is below:
 ```bash
 # edit the VERSION file, e.g. from '0.4.0-dev' to '0.4.0'
 vim VERSION
@@ -27,9 +27,9 @@ git ...
 
 ## CI/CD
 
-There are two GitHub Actions workflows for testing that:
+There are two GitHub Actions workflows for that ensure that:
 1. the makefile and meson build systems can build, install working versions of squashfs-mount.
-2. the workflow for creating artifacts (currently a source RPM).
+2. the all artifacts can be built (currently a source RPM).
 
 All workflows run on each push and PR. Furthermore, the artifacts workflow, [`.github/workflows/artifacts.yml`](https://github.com/eth-cscs/squashfs-mount/blob/master/.github/workflows/artifacts.yml), runs a `tag-release` job when a tag is created, that automatically generates a GitHub release and uploads the artifacts to the release.
 

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,10 @@ install-suid: install
 	chown root:root $(DESTDIR)$(bindir)/squashfs-mount
 	chmod u+s $(DESTDIR)$(bindir)/squashfs-mount
 
+rpm:
+	./generate-rpm.sh -b`pwd`/rpmbuild
+	rpmbuild -bs --define "_topdir `pwd`/rpmbuild" `pwd`/rpmbuild/SPECS/squashfs-mount.spec
+
 clean:
 	rm -f squashfs-mount squashfs-mount.o
+	rm -rf rpmbuild

--- a/ci/Dockerfile.rpm
+++ b/ci/Dockerfile.rpm
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+
+# For building and testing rpm files in GitHub Action pipeline.
+
+FROM registry.suse.com/bci/bci-base
+
+RUN zypper install -y libmount-devel gcc make rpm-build git sudo

--- a/ci/test-mount.sh
+++ b/ci/test-mount.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+# Creates a squashfs image, mounts it with squashfs-mount and tests
+# the mounted image.
+# Requires that squashfs-mount has been installed as suid.
+
+rm -rf test-dir
+mkdir test-dir
+echo "hello world" >> test-dir/test.txt
+mksquashfs test-dir fs.sqsh -noappend 
+sudo mkdir /mntpnt
+result=$(squashfs-mount fs.sqsh /mntpnt cat /mntpnt/test.txt)
+if [[ "$result" != "hello world" ]]; then
+    echo "------ unexpected result: \"$result\""
+    exit 1;
+else
+    echo "------ Success"
+fi
+

--- a/generate-rpm.sh
+++ b/generate-rpm.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# By default use the current path as the root for source and build.
+# This can be configured using command line args for out of tree builds.
+source_path=$(pwd)
+build_path=$(pwd)/rpmbuild
+while getopts s:b: flag
+do
+    case "${flag}" in
+        s) source_path=${OPTARG};;
+        b) build_path=${OPTARG};;
+    esac
+done
+
+# Strip `-dev` from VERSION if exsists because RPM requires version numbers of
+# the form X.Y.Z
+version=$(sed 's\-.*$\\' VERSION)
+pkg_name=squashfs-mount-${version}
+mkdir -p ${build_path}/{SOURCES,BUILD,RPMS,SRPMS,SPECS}
+
+tar_path=${build_path}/${pkg_name}
+mkdir -p ${tar_path}
+
+cp ${source_path}/squashfs-mount.c ${tar_path}
+cp ${source_path}/Makefile ${tar_path}
+cp ${source_path}/LICENSE ${tar_path}
+
+tar_file=${build_path}/SOURCES/${pkg_name}.tar.gz
+tar -czf ${tar_file} --directory ${build_path} ${pkg_name}
+
+spec_file=${build_path}/SPECS/squashfs-mount.spec
+cp squashfs-mount.spec.in ${spec_file}
+sed -i "s|SQMNT_VERSION|${version}|g" ${spec_file}

--- a/generate-rpm.sh
+++ b/generate-rpm.sh
@@ -1,33 +1,36 @@
-#!/bin/bash
+#!/bin/sh
 
 # By default use the current path as the root for source and build.
 # This can be configured using command line args for out of tree builds.
-source_path=$(pwd)
-build_path=$(pwd)/rpmbuild
+source_path="$PWD"
+build_path="$PWD/rpmbuild"
 while getopts s:b: flag
 do
     case "${flag}" in
         s) source_path=${OPTARG};;
         b) build_path=${OPTARG};;
+        *) echo "unknown flag ${flag}"; exit 1 ;;
     esac
 done
 
 # Strip `-dev` from VERSION if exsists because RPM requires version numbers of
 # the form X.Y.Z
-version=$(sed 's\-.*$\\' VERSION)
-pkg_name=squashfs-mount-${version}
-mkdir -p ${build_path}/{SOURCES,BUILD,RPMS,SRPMS,SPECS}
+# shellcheck disable=SC1003
+version="$(sed 's\-.*$\\' VERSION)"
+pkg_name="squashfs-mount-${version}"
+mkdir -p "${build_path}"
+(cd "${build_path}" && mkdir SOURCES BUILD RPMS SRPMS SPECS)
 
-tar_path=${build_path}/${pkg_name}
-mkdir -p ${tar_path}
+tar_path="${build_path}/${pkg_name}"
+mkdir -p "${tar_path}"
 
-cp ${source_path}/squashfs-mount.c ${tar_path}
-cp ${source_path}/Makefile ${tar_path}
-cp ${source_path}/LICENSE ${tar_path}
+cp "${source_path}/squashfs-mount.c" "${tar_path}"
+cp "${source_path}/Makefile" "${tar_path}"
+cp "${source_path}/LICENSE" "${tar_path}"
 
-tar_file=${build_path}/SOURCES/${pkg_name}.tar.gz
-tar -czf ${tar_file} --directory ${build_path} ${pkg_name}
+tar_file="${build_path}/SOURCES/${pkg_name}.tar.gz"
+tar -czf "${tar_file}" --directory "${build_path} ${pkg_name}"
 
-spec_file=${build_path}/SPECS/squashfs-mount.spec
-cp squashfs-mount.spec.in ${spec_file}
-sed -i "s|SQMNT_VERSION|${version}|g" ${spec_file}
+spec_file="${build_path}/SPECS/squashfs-mount.spec"
+cp squashfs-mount.spec.in "${spec_file}"
+sed -i "s|SQMNT_VERSION|${version}|g" "${spec_file}"

--- a/generate-rpm.sh
+++ b/generate-rpm.sh
@@ -29,7 +29,7 @@ cp "${source_path}/Makefile" "${tar_path}"
 cp "${source_path}/LICENSE" "${tar_path}"
 
 tar_file="${build_path}/SOURCES/${pkg_name}.tar.gz"
-tar -czf "${tar_file}" --directory "${build_path} ${pkg_name}"
+tar -czf "${tar_file}" --directory "${build_path}" "${pkg_name}"
 
 spec_file="${build_path}/SPECS/squashfs-mount.spec"
 cp squashfs-mount.spec.in "${spec_file}"

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('squashfs-mount', ['c'], default_options : ['c_std=c99'], version: files('VERSION'), meson_version: '>=0.60')
+project('squashfs-mount', ['c'], default_options : ['c_std=c99'], version: files('VERSION'), meson_version: '>=0.57')
 
 # Look for libmount
 dep_libmount = dependency('mount')
@@ -8,7 +8,7 @@ version = meson.project_version()
 exec = executable('squashfs-mount',
               sources: ['squashfs-mount.c'],
               dependencies: [dep_libmount],
-              c_args: [f'-DVERSION="@version@"'],
+              c_args: ['-DVERSION="@0@"'.format(version)],
               # equivalent to: `chown root:root $exec; chmod u+s $exec;` before installation.
               install_mode: ['rwsr-xr-x', 'root', 'root'],
               install: true)

--- a/squashfs-mount.spec.in
+++ b/squashfs-mount.spec.in
@@ -7,8 +7,6 @@ License:        BSD3
 URL:            https://github.com/eth-cscs/squashfs-mount
 Source0:        %{name}-%{version}.tar.gz
 
-BuildArch:  x86_64
-
 %description
 A small setuid binary that mounts a squashfs image in a mount namespace then executes a command as the normal user.
 

--- a/squashfs-mount.spec.in
+++ b/squashfs-mount.spec.in
@@ -1,0 +1,26 @@
+Name:           squashfs-mount
+Version:        SQMNT_VERSION
+Release:        1%{?dist}
+Summary:        setuid mount squashfs utility.
+
+License:        BSD3
+URL:            https://github.com/eth-cscs/squashfs-mount
+Source0:        %{name}-%{version}.tar.gz
+
+BuildArch:  x86_64
+
+%description
+A small setuid binary that mounts a squashfs image in a mount namespace then executes a command as the normal user.
+
+%prep
+%setup -q
+
+%build
+make %{?_smp_mflags}
+
+%install
+sudo make install-suid prefix=%{_prefix} DESTDIR=%{buildroot}
+
+%files
+%license LICENSE
+%{_bindir}/%{name}


### PR DESCRIPTION
Add CI/CD workflows:
* test build and install using makefile and meson.
* generate and test installation of RPM - and upload RPM for releases

Also add support for RPM generation
* makefile target for generating a source RPM
* helper script for building RPM package
* template RPM spec file

Also add some basic development notes.