### PR TITLE
rpm build fixes

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -17,9 +17,9 @@ jobs:
       - name: build-srpm
         run: |
           make rpm
-          sudo rpmbuild --rebuild ./rpmbuild/SRPMS/squashfs-mount*.src.rpm --define "_topdir $(pwd)/rpmbuild"
-          sudo rpm --install rpmbuild/RPMS/x86_64/squashfs-mount*.rpm
-          cp rpmbuild/SRPMS/* .
+          sudo rpmbuild --rebuild ./rpm/SRPMS/squashfs-mount*.src.rpm --define "_topdir $(pwd)/rpm"
+          sudo rpm --install rpm/RPMS/x86_64/squashfs-mount*.rpm
+          cp rpm/SRPMS/* .
       - name: upload-rpm
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.o
 *.squashfs
 squashfs-mount
-rpmbuild
+rpm
 *.sqsh
 test-dir

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ CFLAGS+=-DVERSION=\"$(VERSION_FULL)\"
 SQUASHFS_MOUNT_CFLAGS = -std=c99
 SQUASHFS_MOUNT_LDFLAGS = -lmount
 
+RPMBUILD ?= rpmbuild
+
 all: squashfs-mount
 
 %.o: %.c
@@ -29,10 +31,9 @@ install-suid: install
 	chown root:root $(DESTDIR)$(bindir)/squashfs-mount
 	chmod u+s $(DESTDIR)$(bindir)/squashfs-mount
 
-rpm:
-	./generate-rpm.sh -b`pwd`/rpmbuild
-	rpmbuild -bs --define "_topdir `pwd`/rpmbuild" `pwd`/rpmbuild/SPECS/squashfs-mount.spec
+rpm: squashfs-mount.c VERSION LICENSE Makefile
+	./generate-rpm.sh -b $@
+	$(RPMBUILD) -bs --define "_topdir $@" $@/SPECS/squashfs-mount.spec
 
 clean:
-	rm -f squashfs-mount squashfs-mount.o
-	rm -rf rpmbuild
+	rm -rf squashfs-mount squashfs-mount.o rpm

--- a/generate-rpm.sh
+++ b/generate-rpm.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # By default use the current path as the root for source and build.
 # This can be configured using command line args for out of tree builds.
 source_path="$PWD"
@@ -19,7 +21,7 @@ done
 version="$(sed 's\-.*$\\' VERSION)"
 pkg_name="squashfs-mount-${version}"
 mkdir -p "${build_path}"
-(cd "${build_path}" && mkdir SOURCES BUILD RPMS SRPMS SPECS)
+(cd "${build_path}" && mkdir -p SOURCES BUILD RPMS SRPMS SPECS)
 
 tar_path="${build_path}/${pkg_name}"
 mkdir -p "${tar_path}"


### PR DESCRIPTION
add missing prereqs in the makefile and add missing `set -e` flag in shell script