### PR TITLE
Forwarding environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ squashfs-mount
 rpm
 *.sqsh
 test-dir
+.cache

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 effectively runs `mount -n -o loop,nosuid,nodev,ro -t squashfs [image] [mountpoint]` in
 a mount namespace and then executes the given command as the normal user.
 
+## Environment Variables
+
+The kernel unsets some environment variables, e.g. `LD_LIBRARY_PATH` and `LD_PRELOAD`, in setuid binaries for obvious security reasons. `squashfs-mount` will look for environment variables that have the `SQFSMNT_FWD_` prefix, and strip the prefix from the variable for the executed binary. This can be used to foward variables like `LD_LIBRARY_PATH` safely. For example:
+
+```bash
+SQFSMNT_FWD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH squashfs-mount $image:$mount -- bash
+```
 
 ## Motivation
 
@@ -12,74 +19,9 @@ single file, no need to extract. The downside is they can only be mounted
 "rootless" (well, using setuid fusermount) with `squashfuse`, which has two
 issues:
 
-1. Bad performance compared to the Linux kernel. Using a 700MB gzip compressed squashfs
-   file containing GCC, the time to build a subset (2k targets) of LLVM 14.0.5:
-   - squashfs-mount: `8m 9.52s`;
-   - squashfuse 0.1.103 / fuse 3.9.0: `12m 49.00s`.
+1. Bad performance compared to the Linux kernel (this situation is improving over time).
 
-   squashfuse has about 57% overhead compiling LLVM.
-
-   Another "latency" benchmark, compiling a hello world C file:
-   ```
-   Benchmark 1: ./squashfuse/gcc-10.3.0-ammihitysch7br7kke3pntiplfblqpdu/bin/gcc -c main.c
-     Time (mean ± σ):      61.2 ms ±   3.1 ms    [User: 13.1 ms, System: 6.2 ms]
-     Range (min … max):    53.5 ms …  70.3 ms    50 runs
-
-   Benchmark 2: ./squashfuse/gcc-11.3.0-cm7ueuil6ppl3yp56esfcan6lmlis63b/bin/gcc -c main.c
-     Time (mean ± σ):      58.8 ms ±   2.9 ms    [User: 13.0 ms, System: 7.0 ms]
-     Range (min … max):    53.3 ms …  66.7 ms    52 runs
-
-   Benchmark 3: ./squashfuse/gcc-12.1.0-zc3agmabcw3w22q3zlxopeangnn6dipp/bin/gcc -c main.c
-     Time (mean ± σ):      54.4 ms ±   3.3 ms    [User: 13.6 ms, System: 6.7 ms]
-     Range (min … max):    48.0 ms …  66.1 ms    49 runs
-
-   Benchmark 4: ./squashfuse/gcc-9.5.0-dwbag4fgidanx5rgm2apidnajtpneza6/bin/gcc -c main.c
-     Time (mean ± σ):      78.5 ms ±   3.9 ms    [User: 13.3 ms, System: 5.5 ms]
-     Range (min … max):    74.0 ms …  90.0 ms    39 runs
-
-   Benchmark 5: /usr/bin/gcc -c main.c
-     Time (mean ± σ):      16.6 ms ±   1.7 ms    [User: 12.1 ms, System: 4.5 ms]
-     Range (min … max):    11.8 ms …  20.4 ms    178 runs
-
-   Summary
-     '/usr/bin/gcc -c main.c' ran
-       3.27 ± 0.39 times faster than './squashfuse/gcc-12.1.0-zc3agmabcw3w22q3zlxopeangnn6dipp/bin/gcc -c main.c'
-       3.54 ± 0.40 times faster than './squashfuse/gcc-11.3.0-cm7ueuil6ppl3yp56esfcan6lmlis63b/bin/gcc -c main.c'
-       3.68 ± 0.42 times faster than './squashfuse/gcc-10.3.0-ammihitysch7br7kke3pntiplfblqpdu/bin/gcc -c main.c'
-       4.72 ± 0.54 times faster than './squashfuse/gcc-9.5.0-dwbag4fgidanx5rgm2apidnajtpneza6/bin/gcc -c main.c'
-   ```
-   versus
-   ```
-   Benchmark 1: ./native/gcc-10.3.0-ammihitysch7br7kke3pntiplfblqpdu/bin/gcc -c main.c
-     Time (mean ± σ):      15.7 ms ±   1.6 ms    [User: 11.0 ms, System: 4.6 ms]
-     Range (min … max):    10.3 ms …  19.4 ms    236 runs
-
-   Benchmark 2: ./native/gcc-11.3.0-cm7ueuil6ppl3yp56esfcan6lmlis63b/bin/gcc -c main.c
-     Time (mean ± σ):      16.0 ms ±   1.8 ms    [User: 11.4 ms, System: 4.5 ms]
-     Range (min … max):    10.6 ms …  19.6 ms    236 runs
-
-   Benchmark 3: ./native/gcc-12.1.0-zc3agmabcw3w22q3zlxopeangnn6dipp/bin/gcc -c main.c
-     Time (mean ± σ):      16.8 ms ±   1.6 ms    [User: 11.6 ms, System: 5.2 ms]
-     Range (min … max):    11.3 ms …  20.3 ms    192 runs
-
-   Benchmark 4: ./native/gcc-9.5.0-dwbag4fgidanx5rgm2apidnajtpneza6/bin/gcc -c main.c
-     Time (mean ± σ):      15.3 ms ±   1.5 ms    [User: 11.1 ms, System: 4.1 ms]
-     Range (min … max):    10.2 ms …  18.4 ms    195 runs
-
-   Benchmark 5: /usr/bin/gcc -c main.c
-     Time (mean ± σ):      16.5 ms ±   1.9 ms    [User: 11.9 ms, System: 4.6 ms]
-     Range (min … max):    10.3 ms …  20.0 ms    187 runs
-
-   Summary
-     './native/gcc-9.5.0-dwbag4fgidanx5rgm2apidnajtpneza6/bin/gcc -c main.c' ran
-       1.02 ± 0.15 times faster than './native/gcc-10.3.0-ammihitysch7br7kke3pntiplfblqpdu/bin/gcc -c main.c'
-       1.04 ± 0.16 times faster than './native/gcc-11.3.0-cm7ueuil6ppl3yp56esfcan6lmlis63b/bin/gcc -c main.c'
-       1.08 ± 0.17 times faster than '/usr/bin/gcc -c main.c'
-       1.10 ± 0.15 times faster than './native/gcc-12.1.0-zc3agmabcw3w22q3zlxopeangnn6dipp/bin/gcc -c main.c'
-   ```
-
-2. Inconvenient when scripting, as illustrated by [NVIDIA
-   enroot](https://github.com/NVIDIA/enroot):
+2. Inconvenient and complicated implementation, as illustrated by [NVIDIA enroot](https://github.com/NVIDIA/enroot):
 
    ```bash
    # Mount the image as the lower layer.
@@ -91,11 +33,22 @@ issues:
    done
    ```
 
+3. There are frequent CVEs related to user namespaces, which see the feature disabled on HPC systems while we wait for a fix (or disabled all-together out of an abundance of caution.)
+
 ## Dependencies
 
 - `util-linux` (libmount)
 
 ## Install instructions
+
+### Using Meson
+
+```console
+mkdir build
+cd build
+meson setup ..
+sudo ninja install
+```
 
 ### From Makefile
 
@@ -110,7 +63,7 @@ sudo chmod u+s ./install/bin/squashfs-mount
 
 Or use the `install-suid` target:
 
-```
+```console
 make install prefix=./install
 sudo make install-suid prefix=./install
 ```
@@ -119,7 +72,7 @@ sudo make install-suid prefix=./install
 
 The `rpm` makefile target generates a source RPM, with `_topdir` in `$(pwd)/rpmbuild`.
 The source RPM can be compiled
-```
+```console
 make rpm
 topdir="$(pwd)/rpmbuild"
 sudo rpmbuild --rebuild "$topdir"/SRPMS/squashfs-mount*.src.rpm --define "_topdir $topdir"

--- a/ci/tests.bats
+++ b/ci/tests.bats
@@ -61,3 +61,9 @@ function teardown() {
     run bash -c 'squashfs-mount -- readlink /proc/$$/ns/mnt'
     assert_output --partial ${original_mnt}
 }
+
+@test "fwd_env_ld_library_path" {
+    # check forwarding for LD_LIBRARY_PATH
+    run bash -c 'SQFSMNT_FWD_LD_LIBRARY_PATH=foo squashfs-mount -- sh -c "env | grep ^LD_LIBRARY_PATH"'
+    assert_output --partial "foo"
+}

--- a/squashfs-mount.c
+++ b/squashfs-mount.c
@@ -307,6 +307,8 @@ int main(int argc, char **argv) {
   fwd_argv = argv + (positional_args + 1);
   // if no mountpoints given, run command directly
   if (positional_args == 0) {
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0)
+      err(EXIT_FAILURE, "PR_SET_NO_NEW_PRIVS failed");
     fprintf(stderr, "Warning no <image>:<mountpoint> argument was given.\n");
     return execvp(fwd_argv[0], fwd_argv);
   }

--- a/squashfs-mount.c
+++ b/squashfs-mount.c
@@ -307,8 +307,7 @@ int main(int argc, char **argv) {
   fwd_argv = argv + (positional_args + 1);
   // if no mountpoints given, run command directly
   if (positional_args == 0) {
-    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0)
-      err(EXIT_FAILURE, "PR_SET_NO_NEW_PRIVS failed");
+    return_to_user_and_no_new_privs(uid);
     fprintf(stderr, "Warning no <image>:<mountpoint> argument was given.\n");
     char **new_env = fwd_env();
     if (new_env == NULL) {

--- a/squashfs-mount.c
+++ b/squashfs-mount.c
@@ -310,7 +310,11 @@ int main(int argc, char **argv) {
     if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0)
       err(EXIT_FAILURE, "PR_SET_NO_NEW_PRIVS failed");
     fprintf(stderr, "Warning no <image>:<mountpoint> argument was given.\n");
-    return execvp(fwd_argv[0], fwd_argv);
+    char **new_env = fwd_env();
+    if (new_env == NULL) {
+      err(EXIT_FAILURE, "failed to modify the environment variables");
+    }
+    return execvpe(fwd_argv[0], fwd_argv, new_env);
   }
 
   mount_entries = parse_mount_entries(argv, positional_args);


### PR DESCRIPTION
The kernel unsets some environment variables, e.g. `LD_LIBRARY_PATH` and `LD_PRELOAD`, in setuid binaries for obvious security reasons.

This PR implements a feature that looks for environment variables that have the `SQFSMNT_FWD_` prefix, and strip the prefix from the variable for the executed binary.

This can be used to forward variables like `LD_LIBRARY_PATH` safely. For example:

```bash
SQFSMNT_FWD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH squashfs-mount $image:$mount -- bash
```