### PR TITLE
Makefile: Allow to pass CPPFLAGS flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ prefix = /usr/local
 exec_prefix = $(prefix)
 bindir = $(exec_prefix)/bin
 
+CPPFLAGS ?=
 CFLAGS ?= -Os -Wall -Wpedantic -Wextra -Wformat-overflow -Werror-implicit-function-declaration
 LDFLAGS ?= -Wl,--gc-sections,-s
 
@@ -16,7 +17,7 @@ RPMBUILD ?= rpmbuild
 all: squashfs-mount
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(SQUASHFS_MOUNT_CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(SQUASHFS_MOUNT_CFLAGS) -c -o $@ $<
 
 squashfs-mount.o: VERSION
 


### PR DESCRIPTION
While preparing squashfs-mount for Debian it was noticed that CPPFLAGS passed by dpkg-buildflags during the builds are not passed down. dpkg-buildflags in Debian at the point of writing, passes

	-Wdate-time -D_FORTIFY_SOURCE=2

Allow to pass own CPPFLAGS and fallback to the current behaviour if not set earlier.

Link: https://qa.debian.org/bls/packages/s/squashfs-mount.html