### PR TITLE
Add SQUASHFS_MOUNT_OFFSET enviroment varialbe

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -21,7 +21,7 @@ jobs:
           sudo rpm --install "$(find rpm/RPMS -name '*.rpm' -type f -print -quit)"
           find rpm -name '*.rpm' -type f -exec cp {} . \;
       - name: upload-rpm
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rpm
           path: '*.rpm'
@@ -31,7 +31,7 @@ jobs:
     needs: rpm
     steps:
       - name: download-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rpm
       - name: release

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 
 jobs:
   rpm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: registry.suse.com/bci/bci-base:15.3
     steps:
       - name: setup-environment
@@ -27,7 +27,7 @@ jobs:
           path: '*.rpm'
 
   tag-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: rpm
     steps:
       - name: download-artifacts

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   makefile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: setup
@@ -30,7 +30,7 @@ jobs:
           /bats-core-1.9.0/bin/bats ci/tests.bats
 
   meson:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: setup

--- a/ci/tests.bats
+++ b/ci/tests.bats
@@ -55,6 +55,20 @@ function teardown() {
     run squashfs-mount ${SQFSDIR}/tools-offset.sqfs@2048:/user-tools -- cat /user-tools/tools/fileB.txt
 }
 
+@test "mount_offset_image_neg_offset" {
+    # offset must be > 0
+    run squashfs-mount ${SQFSDIR}/tools-offset.sqfs@-2048434:/user-tools -- cat /user-tools/tools/fileB.txt
+    assert_failure
+    assert_line  --regexp ".*offset.* must be >0: .*"
+}
+
+@test "mount_offset_image_offset_twice" {
+    # only one @<offset> is allowed
+    run squashfs-mount ${SQFSDIR}/tools-offset.sqfs@2@2:/user-tools -- cat /user-tools/tools/fileB.txt
+    assert_failure
+    assert_line  --regexp ".*invalid format: .*"
+}
+
 @test "mount_images" {
     run squashfs-mount ${SQFSDIR}/binaries.sqfs:/user-environment ${SQFSDIR}/profilers.sqfs:/user-profilers ${SQFSDIR}/tools.sqfs:/user-tools -- cat /user-environment/spack-install/fileA.txt
 }

--- a/ci/tests.bats
+++ b/ci/tests.bats
@@ -30,6 +30,16 @@ function setup() {
         echo "tools stack" >> tools/fileB.txt
     )
     mksquashfs "$dd"  ${SQFSDIR}/tools.sqfs -quiet -noappend && rm -r "$dd"
+
+    dd=$(mktemp -d)
+    (
+        umask 022
+        cd "$dd" || exit
+        mkdir tools
+        echo "tools stack" >> tools/fileB.txt
+    )
+    mksquashfs "$dd"  ${SQFSDIR}/tools-offset.sqfs -offset 2048 -quiet -noappend && rm -r "$dd"
+
 }
 
 function teardown() {
@@ -39,6 +49,10 @@ function teardown() {
 
 @test "mount_single_image" {
     run squashfs-mount ${SQFSDIR}/binaries.sqfs:/user-environment -- cat /user-environment/spack-install/fileA.txt
+}
+
+@test "mount_offset_image" {
+    run squashfs-mount ${SQFSDIR}/tools-offset.sqfs@2048:/user-tools -- cat /user-tools/tools/fileB.txt
 }
 
 @test "mount_images" {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -90,5 +90,5 @@ git commit -m "Release ${NEW_VERSION}"
 
 # Tag the new release
 if [ "$_tag" -eq "1" ]; then
-    git tag -a "$NEW_VERSION" -m "Release version $NEW_VERSION"
+    git tag -a "v$NEW_VERSION" -m "Release version $NEW_VERSION"
 fi

--- a/squashfs-mount.c
+++ b/squashfs-mount.c
@@ -182,6 +182,9 @@ static mount_entry_t *parse_mount_entries(char **argv, int argc) {
       char *offset_str = strtok(NULL, ":");
       if (offset_str) {
         if (offset_str[0] == '@') {
+          if (strtoll(offset_str + 1, NULL, 10) < 0) {
+            errx(EXIT_FAILURE, "invalid format %s", argv[i]);
+          }
           offset = strtoul(offset_str + 1, NULL, 10);
         } else {
           errx(EXIT_FAILURE, "invalid format %s", argv[i]);

--- a/squashfs-mount.c
+++ b/squashfs-mount.c
@@ -304,7 +304,7 @@ int main(int argc, char **argv) {
     errx(EXIT_FAILURE, "Unknown flag %s", argv[i]);
   }
 
-  char *OFFSET=getenv("SQFSMNT_OFFSET");
+  char *OFFSET=getenv("SQUASHFS_MOUNT_OFFSET");
   char *endptr;
   if (OFFSET != NULL) offset=strtoul(OFFSET, &endptr, 10);
 

--- a/squashfs-mount.c
+++ b/squashfs-mount.c
@@ -23,6 +23,8 @@
     exit(EXIT_FAILURE);                                                        \
   } while (0)
 
+unsigned long offset=0;
+
 static void help(char const *argv0) {
   exit_with_error("Usage: %s <image>:<mountpoint> [<image>:<mountpoint>]...  "
                   "-- <command> [args...]\n",
@@ -96,7 +98,9 @@ static void do_mount(const mount_entry_t *entry) {
   if (mnt_context_set_fstype(cxt, "squashfs") != 0)
     errx(EXIT_FAILURE, "Failed to set fstype to squashfs");
 
-  if (mnt_context_append_options(cxt, "loop,nosuid,nodev,ro") != 0)
+  char buffer_jkdhg[100] = {0};
+  snprintf(buffer_jkdhg, 50, "loop,nosuid,nodev,ro,offset=%lu", offset);
+  if (mnt_context_append_options(cxt, buffer_jkdhg) != 0)
     errx(EXIT_FAILURE, "Failed to set mount options");
 
   if (mnt_context_set_source(cxt, entry->squashfs_file) != 0)
@@ -299,6 +303,10 @@ int main(int argc, char **argv) {
     // Error on unrecognized flags.
     errx(EXIT_FAILURE, "Unknown flag %s", argv[i]);
   }
+
+  char *OFFSET=getenv("SQFSMNT_OFFSET");
+  char *endptr;
+  if (OFFSET != NULL) offset=strtoul(OFFSET, &endptr, 10);
 
   if (argc <= positional_args + 1) {
     exit_with_error("no command given");

--- a/squashfs-mount.c
+++ b/squashfs-mount.c
@@ -38,10 +38,9 @@ typedef struct {
 
 unsigned long get_file_size(const char *filename) {
     struct stat file_status;
-    if (stat(filename, &file_status) < 0) {
+    if (stat(filename, &file_status) != 0) {
         errx(EXIT_FAILURE, "Failed to stat file %s", filename);
     }
-
     return file_status.st_size;
 }
 

--- a/squashfs-mount.c
+++ b/squashfs-mount.c
@@ -195,20 +195,21 @@ static mount_entry_t *parse_mount_entries(const char **argv, int argc) {
     }
     // if @offset is present, attempt to parse offset
     if ((offset_str = strtok(NULL, "@"))) {
-      char *endptr;
       // check if value is negative
-      if (strtoll(offset_str, NULL, 10) < 0) {
-        errx(EXIT_FAILURE, "invalid value in offset: %s", argv[i]);
+      long long _f;
+      if ((_f = strtoll(offset_str, NULL, 10)) < 0) {
+        errx(EXIT_FAILURE, "offset (=%lld) must be >0: %s", _f, argv[i]);
       }
       // parse offset
+      char *endptr;
       offset = strtoul(offset_str, &endptr, 10);
-      if (errno != 0 || *endptr != '\0') {
-        errx(EXIT_FAILURE, "invalid value in offset: %s", argv[i]);
+      if (*endptr != '\0') {
+        errx(EXIT_FAILURE, "invalid value in offset: %s from %s", offset_str, argv[i]);
       }
-    }
-    // expect file_and_offset only contains one `@`
-    if (strtok(NULL, "@")) {
-      errx(EXIT_FAILURE, "invalid format %s", argv[i]);
+      // expect file_and_offset only contains one `@`
+      if (strtok(NULL, "@")) {
+        errx(EXIT_FAILURE, "invalid format: %s", argv[i]);
+      }
     }
 
     strcpy(mount_entries[i].squashfs_file, file);


### PR DESCRIPTION
This would allow the offset value to be passed in through an enviroment variable `SQUASHFS_MOUNT_OFFSET`. The call to `strtoul` should sanatize any potentially malicious values being passed in. This feature is quite useful when there is other data (or code) before the squashfs file that needs to be ignored.